### PR TITLE
Add show history function for popup view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,21 +2,27 @@ import './style.css'
 
 import {countsKey} from "./constants";
 
-
-
 chrome.storage.local.get(null, ( content ) => {
-    const app = document.querySelector<HTMLDivElement>('#app')!;
-
     let counts = [];
     for(let k in content){
         let d = new Date(+k);
-        counts.push(`${d}:${content[k]}`);
+        counts.push([`${d.getFullYear()}/${d.getMonth()}/${d.getDate()} ${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`, content[k]]);
     }
 
+    let table = document.createElement('table')
     for(let count in counts.reverse()){
+        let tr = document.createElement('tr');
+        let tdDate = document.createElement('td')
+        tdDate.append(counts[count][0]);
+        tr.append(tdDate)
 
-        let p = document.createElement('p');
-        p.append(counts[count]);
-        app.append(p);
+        let tdCount = document.createElement('td')
+        tdCount.append(counts[count][1]);
+        tr.append(tdCount)
+
+        table.append(tr);
     }
+    const app = document.querySelector<HTMLDivElement>('#app')!;
+    app.append(table)
+
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,10 @@
 {
-  "name": "itinerary",
-  "description": "record tab count",
+  "name": "chrome tab count recorder",
+  "description": "record chrome tab count, you ca track tab count and so on",
   "manifest_version": 3,
   "version": "0.0.1",
-  "chrome_url_overrides": {
-    "newtab": "index.html"
+  "action": {
+    "default_popup": "src/popup.html"
   },
   "background": {
     "service_worker": "src/service.ts"

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./popup.css" />
+  </head>
+  <body style="min-width:180px">
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
This PR added showing tab count history from extension icon popup view. It was updated to table view for history.

---
<img width="192" alt="Screen Shot 2022-12-25 at 3 02 58" src="https://user-images.githubusercontent.com/731436/209446946-d1ae5746-8e0e-4de7-8fef-cb546df94eb0.png">


